### PR TITLE
Command execution code now uses threads instead of signals

### DIFF
--- a/scripts/run_test_suites.py
+++ b/scripts/run_test_suites.py
@@ -74,7 +74,7 @@ optional_options = [
         'be attempted to be terminated, if possible. Fractions of a minute '
         'are allowed [default: %default]',
         default=20.0),
-    make_option('--test_suites_timeout', type='int',
+    make_option('--test_suites_timeout', type='float',
         help='the number of minutes to wait before aborting the current test '
         'suite and terminating the remote cluster. This timeout applies to '
         'how long *all* test suites take to run as a whole. For example, this '
@@ -83,7 +83,7 @@ optional_options = [
         'never finish. An email will be sent saying there was a timeout. '
         'Fractions of a minute are allowed [default: %default]',
         default=240.0),
-    make_option('--teardown_timeout', type='int',
+    make_option('--teardown_timeout', type='float',
         help='the number of minutes to allow the remote cluster to be '
         'terminated before aborting. An email will be sent saying there was a '
         'timeout during cluster termination, with a warning that the user '

--- a/scripts/run_test_suites.py
+++ b/scripts/run_test_suites.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 from __future__ import division
 
-__author__ = "Jai Rideout"
+__author__ = "Jai Ram Rideout"
 __copyright__ = "Copyright 2012, The QIIME project"
 __credits__ = ["Jai Ram Rideout"]
 __license__ = "GPL"
@@ -67,28 +67,29 @@ optional_options = [
         'file) for running the test suite(s) on. You should only need a '
         'single-node cluster [default: starcluster config default template]',
         default=None),
-    make_option('--setup_timeout', type='int',
+    make_option('--setup_timeout', type='float',
         help='the number of minutes to allow the remote cluster to be '
         'created and initialized before aborting. An email will be sent '
         'saying there was a timeout during cluster setup, and the cluster '
-        'be attempted to be terminated, if possible [default: %default]',
-        default=20),
+        'be attempted to be terminated, if possible. Fractions of a minute '
+        'are allowed [default: %default]',
+        default=20.0),
     make_option('--test_suites_timeout', type='int',
         help='the number of minutes to wait before aborting the current test '
         'suite and terminating the remote cluster. This timeout applies to '
         'how long *all* test suites take to run as a whole. For example, this '
         'option is useful if some tests have a chance of "hanging", or if '
         'something happens on the remote cluster that causes a command to '
-        'never finish. An email will be sent saying there was a timeout '
-        '[default: %default]',
-        default=240),
+        'never finish. An email will be sent saying there was a timeout. '
+        'Fractions of a minute are allowed [default: %default]',
+        default=240.0),
     make_option('--teardown_timeout', type='int',
         help='the number of minutes to allow the remote cluster to be '
         'terminated before aborting. An email will be sent saying there was a '
         'timeout during cluster termination, with a warning that the user '
-        'should check that the cluster did indeed shut down correctly '
-        '[default: %default]',
-        default=20),
+        'should check that the cluster did indeed shut down correctly. '
+        'Fractions of a minute are allowed [default: %default]',
+        default=20.0),
     make_option('--starcluster_exe_fp', type='string',
         help='the full path to the starcluster executable. By default, '
         'will look for "starcluster" in PATH [default: %default]',

--- a/tests/test_run_test_suites.py
+++ b/tests/test_run_test_suites.py
@@ -19,8 +19,7 @@ from unittest import main, TestCase
 from automated_testing.run_test_suites import (_build_email_summary,
         _build_test_execution_commands, _can_ignore, _execute_commands,
         _execute_commands_and_build_email, _parse_config_file,
-        _parse_email_list, _parse_email_settings, run_test_suites,
-        _system_call)
+        _parse_email_list, _parse_email_settings, run_test_suites)
 
 class RunTestSuitesTests(TestCase):
     """Tests for the run_test_suites.py module."""
@@ -594,12 +593,6 @@ class RunTestSuitesTests(TestCase):
         self.assertEqual(_can_ignore(self.email_list4[0]), False)
         self.assertEqual(_can_ignore(self.email_list4[1]), False)
         self.assertEqual(_can_ignore(self.email_list4[2]), True)
-
-    def test_system_call(self):
-        """Test making system calls and capturing output."""
-        exp = ('foo\n', '', 0)
-        obs = _system_call('echo foo')
-        self.assertEqual(obs, exp)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The code that executes commands now spawns a worker thread to execute these commands. The command timeout code now uses the timeout mechanism provided by Python's threading module instead of relying on `signal.SIGALRM`, which caused a number of issues (see issue #1 for more details).

Benefits of this new approach:
1. Multiple instances of the script should play nicer with each other.
2. If a command times out, we now get a log file for it with output right up to when it timed out. This will be extremely useful for debugging because we now have context of exactly where the timeout occurred.
3. The code is closer to being platform-independent (i.e. running on Windows). There is now only a single spot in the code that won't work on Windows, but this will be fixed whenever we get to tackling issue #6.
4. If a process times out, it is now terminated.
5. We can specify fractions of minutes for the length of the timeouts. This is mostly beneficial for the unit tests, which previously took ~3 minutes to run because the smallest timeout I could give was 1 minute (and so unit tests that tested that timeouts worked correctly had to each run for at least 1 minute).

These changes were tested on Mac OS X and Ubuntu (unit tests and real examples).

This fixes issue #1.
